### PR TITLE
Do not package tests as a first-level namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="Apache V2.0",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests", "tests.*")),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Right now the `tests/` folder will be installed to the root site-packages where it can clobber (due to the same accidental error) other packages data. This is not ideal and should be changed if possible. Proposing this as part of the [submission to conda-forge review](https://github.com/conda-forge/staged-recipes/pull/17821).